### PR TITLE
Déplacement des attachments hors du répertoire public

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ native-files
 
 /db/data.yml
 
+uploaded_files

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -1,0 +1,11 @@
+class AttachmentsController < ApplicationController
+
+  def download
+    attachment = Attachment.find_by(id: params[:attachment_id])
+    head(:not_found)    and return if attachment.nil?
+    head(:forbidden)    and return unless current_user.can?(:une)
+    head(:bad_request)  and return unless File.exist?(attachment.image.path)
+
+    send_file attachment.image.path(params[:style].to_sym), filename: "#{attachment.element.id}#{File.extname(attachment.image.path(params[:style].to_sym))}", disposition: "inline"
+  end
+end

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -1,9 +1,10 @@
 class Attachment < ApplicationRecord
 	belongs_to :element, polymorphic: true
 
-	has_attached_file :image, :styles => { :medium => "300x300>", :thumb => "100x100>" }
+	has_attached_file :image, path: ":rails_root/uploaded_files/:id/:style.:extension",
+                             url: "attachment/:id/:style.:extension",
+                          styles: { :medium => "300x300>", :thumb => "100x100>" }
 
 	validates_attachment :image, content_type: { content_type: ["image/jpg", "image/jpeg", "image/png", "image/gif"] }
 	validates :user_id, presence: true
-
 end

--- a/app/views/folders/_gallery.html.erb
+++ b/app/views/folders/_gallery.html.erb
@@ -9,7 +9,7 @@
 				<div class="panel-heading">
 					<%= link_to item do %>
 						<% if item.attachments.present? && item.attachments.last.image.exists? %>
-							<%= image_tag item.attachments.last.image(:medium), class:"img-responsive" %>
+							<%= image_tag "/" + item.attachments.last.image(:medium), class:"img-responsive" %>
 						<% else %>
 							<%= image_tag "no-image.png", class:"img-responsive img-rounded" %>
 						<% end %>

--- a/app/views/items/_attachement_form.html.erb
+++ b/app/views/items/_attachement_form.html.erb
@@ -8,7 +8,7 @@
         <%= link_to delete_attachment_item_path(item, attachment.id), data: { confirm: "Etes-vous sûr de supprimer cette pièce jointe ?" } do %>
           <span class="glyphicon glyphicon-remove", title="Supprimer"></span>
         <% end %>
-        <%= image_tag attachment.image.url(:thumb) %>
+        <%= image_tag "/" + attachment.image.url(:thumb) %>
       </div>
     <% end %>
   </div>

--- a/app/views/posts/_post_content.html.erb
+++ b/app/views/posts/_post_content.html.erb
@@ -19,7 +19,7 @@
       <% post.attachments.each_with_index do |a, i| %>
         <div class="col-xs-6">
           <%= link_to post_path(post, slide_id: i) do %>
-            <%= image_tag a.image(:medium), class:"img-thumbnail" %>
+            <%= image_tag "/" + a.image.url(:medium), class:"img-thumbnail" %>
           <% end %>
         </div>
         <% "</div><div class='row'>" if ((i % 2) == 0) %>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -60,7 +60,7 @@
 			<div class="attachments">
 				<% @post.attachments.each do |attachment| %>
 					<div class="attachment-thumbnail">
-						<%= image_tag attachment.image.url(:thumb) %><br />
+						<%= image_tag "/" + attachment.image.url(:thumb) %><br />
 						<%= link_to delete_attachment_post_path(@post, attachment.id), class:"attachment-delete-icon", title:"Supprimer", data: {confirm: "Etes-vous certain de supprimer cette pièce jointe ?"} do %>
 							<i class="glyphicon glyphicon-remove"></i>
 						<% end %>

--- a/app/views/posts/index.atom.builder
+++ b/app/views/posts/index.atom.builder
@@ -21,7 +21,7 @@
           whole_content += "<div class=post-photo-gallery'> "
           post.attachments.each do |a|
             entry.attachements do |attachment|
-                whole_content += image_tag a.image(:thumb) 
+                whole_content += image_tag "/" + a.image(:thumb)
                 whole_content += " &nbsp; "
             end  
           end

--- a/app/views/shared/_carousel.html.erb
+++ b/app/views/shared/_carousel.html.erb
@@ -3,7 +3,7 @@
   <div class="carousel-inner">
   	<% attachments.each_with_index do |attachment, i| %>
 	  	<div class="item <%=  "active" if i==active_slide_id %>">
-	      <%= image_tag attachment.image.url %>
+	      <%= image_tag "/" + attachment.image.url %>
 	      <div class="carousel-caption">
 	      	<%= long_date(attachment.image_updated_at) %>
 	      </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
 
-  
+  # Attachment
+  get "attachment/:attachment_id/:style.:extension", to: "attachments#download", as: "download_attachment"
 
 	# Users
 	devise_for :users, controllers: {
@@ -13,8 +14,6 @@ Rails.application.routes.draw do
 			get :favorites
 		end
 	end
-	
-
 
 	# La Une
 	resources :posts do
@@ -30,8 +29,6 @@ Rails.application.routes.draw do
 			post :upvote
 		end
 	end
-	
-
 
 	# Collector
 	get 'welcome/index'
@@ -50,7 +47,7 @@ Rails.application.routes.draw do
 		end
 	end
 	resources :folders
-	
+
 	# Cron /!\ Pas d'authentification
 	get 'cron/jobs'
 	get 'cron/run'


### PR DESCRIPTION
Ceci permet de laisser les images privées et non accessibles à tous depuis l'extérieur (nécessité d'être loggé)😎

Un petit désagrément (qui m'a pris longtemps à trouver) est qu'il faut précéder a.image() de "/" +, autrement `image_tag` interprète ceci comme devant être servi comme un asset.
(autrement ceci génèrerait une erreur car les images ne sont pas des assets mais des fichiers envoyés via send_file par un controller, après vérification d'accès).

Il faut maintenant écrire un script de migration des uploads actuels vers le nouveau répertoire.

Pour chaque attachement, le path est le suivant:

```
:rails_root/uploaded_files/:attachement_id/:style.:extension
```

Ceci nécessite d'être testé avant d'être déployé (marche chez moi depuis un fresh clone).

Fix #75 